### PR TITLE
[Firebase] Remove fallback credentials for production

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -19,9 +19,9 @@ const firebaseConfig = {
   measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID
 };
 
-// For development - use direct configuration values
-// In production, these would come from environment variables
-if (!firebaseConfig.projectId) {
+// For development builds we provide fallback credentials to make local
+// testing easier. These should **never** be used in production.
+if (process.env.NODE_ENV !== 'production' && !firebaseConfig.projectId) {
   console.warn('Using development Firebase config');
   
   // Development Firebase configuration


### PR DESCRIPTION
## Summary
- resolve Task 7 from AI_AGENT_TASKS.md
- restrict Firebase dev credentials to non-production environments only

## Testing
- `npm run lint`
- `CI=true npm test --silent`
- `npm run build`
