### PR TITLE
[AuthModal] Refine mobile responsiveness

### DIFF
--- a/src/components/Common/AuthModal.js
+++ b/src/components/Common/AuthModal.js
@@ -503,6 +503,16 @@ const ModalContainer = styled.div`
   color: #fff;
   border: 1px solid rgba(130, 161, 191, 0.3);
   position: relative;
+
+  @media (max-width: 480px) {
+    width: 95%;
+    padding: 1.5rem 1rem;
+  }
+
+  @media (max-width: 360px) {
+    padding: 1rem 0.8rem;
+    max-height: calc(100vh - 1rem);
+  }
   
   @keyframes slideIn {
     from {
@@ -526,6 +536,17 @@ const CloseText = styled.span`
   cursor: pointer;
   z-index: 1000;
   transition: color 0.2s;
+
+  @media (max-width: 480px) {
+    font-size: 20px;
+    right: 15px;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 18px;
+    right: 10px;
+    top: 8px;
+  }
   
   &:hover {
     color: #faaa93;
@@ -543,6 +564,15 @@ const ModalTitle = styled.h2`
   margin-bottom: 2rem;
   text-align: center;
   text-shadow: 0 0 10px rgba(250, 170, 147, 0.3);
+
+  @media (max-width: 480px) {
+    font-size: 1.4rem;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 1.2rem;
+    margin-bottom: 1.5rem;
+  }
 `;
 
 const AuthOptionsContainer = styled.div`
@@ -564,6 +594,17 @@ const BackButton = styled.span`
   cursor: pointer;
   z-index: 1000;
   transition: color 0.2s;
+
+  @media (max-width: 480px) {
+    left: 15px;
+    font-size: 20px;
+  }
+
+  @media (max-width: 360px) {
+    left: 10px;
+    font-size: 18px;
+    top: 12px;
+  }
   
   &:hover {
     color: #faaa93;
@@ -586,6 +627,10 @@ const SignUpPrompt = styled.div`
   margin-top: 2rem;
   color: #82a1bf;
   font-size: 0.9rem;
+
+  @media (max-width: 360px) {
+    font-size: 0.8rem;
+  }
 `;
 
 const SignUpLink = styled.span`
@@ -634,6 +679,16 @@ const Input = styled.input`
   text-align: ${props => props.isRTL ? 'right' : 'left'};
   background-color: rgba(26, 26, 46, 0.8);
   color: #fff;
+
+  @media (max-width: 480px) {
+    font-size: 0.9rem;
+    padding: 0.7rem 0.9rem 0.7rem 2.3rem;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 0.85rem;
+    padding: 0.6rem 0.8rem 0.6rem 2rem;
+  }
   
   &:focus {
     outline: none;
@@ -661,6 +716,15 @@ const Button = styled.button`
   z-index: 1;
   letter-spacing: 0.5px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+
+  @media (max-width: 480px) {
+    font-size: 0.95rem;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 0.85rem;
+    padding: 0.7rem;
+  }
   
   &:before {
     content: '';
@@ -740,6 +804,18 @@ const SocialButton = styled.button`
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(130, 161, 191, 0.3);
   backdrop-filter: blur(4px);
+  width: 100%;
+
+  @media (max-width: 480px) {
+    font-size: 0.9rem;
+    gap: 0.5rem;
+    padding: 0.8rem;
+  }
+
+  @media (max-width: 360px) {
+    font-size: 0.8rem;
+    padding: 0.7rem;
+  }
   
   &::before {
     content: '';


### PR DESCRIPTION
## Summary
- improve AuthModal layout on very small screens
- tweak padding and font sizes under 360px width
- adjust close and back button positioning

References: task 11 in `AI_AGENT_TASKS.md`

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Firebase errors)*
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
- `npm run build`
