### PR TITLE
[Dashboard] Add mobile sidebar backdrop

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -140,6 +140,9 @@ const Dashboard = () => {
         <SidebarArea isOpen={sidebarOpen} isMobile={mobileView} isRTL={isRTL}>
           <Sidebar />
         </SidebarArea>
+        {mobileView && sidebarOpen && (
+          <SidebarBackdrop onClick={toggleSidebar} />
+        )}
         
         {/* Main Content */}
         <ContentArea isRTL={isRTL} isMobile={mobileView} sidebarOpen={sidebarOpen}>
@@ -429,6 +432,24 @@ const SidebarArea = styled.div`
     height: calc(100vh - 60px);
     box-shadow: ${props => props.isOpen ? '0 5px 15px rgba(0, 0, 0, 0.1)' : 'none'};
     z-index: 1001;
+  }
+`;
+
+const SidebarBackdrop = styled.div`
+  position: fixed;
+  top: 70px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+
+  @media (max-width: 768px) {
+    top: 60px;
+  }
+
+  @media (min-width: 769px) {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## Summary
- implement mobile sidebar overlay so clicking outside closes the sidebar

References task **16** in `AI_AGENT_TASKS.md`.

## Testing
- `npm run lint`
- `npm test` *(fails: isSupported is not a function)*
- `npm run build` *(fails: storage is not exported from ../../firebase)*