### PR TITLE
[Auth] Reset state on modal close

### DIFF
--- a/src/components/Common/AuthModal.js
+++ b/src/components/Common/AuthModal.js
@@ -65,6 +65,23 @@ const AuthModal = ({ isOpen, onClose }) => {
     };
   }, [isOpen, handleClose]);
 
+  // Close modal on Escape key press
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, handleClose]);
+
   // Ensure state resets if modal is closed externally
   useEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
## Summary
- fix modal closing behavior in `AuthModal` by resetting state on Escape key press

## Testing
- `npm run lint`
- `npm test --silent` *(fails: AuthModal tests due to i18n errors)*
- `npm run test:responsive --silent`