### PR TITLE
[Auth] Fix mobile layout in modal

### DIFF
--- a/src/components/Common/AuthModal.js
+++ b/src/components/Common/AuthModal.js
@@ -536,6 +536,10 @@ const ModalOverlay = styled.div`
   direction: ${props => props.isRTL ? 'rtl' : 'ltr'};
   overflow-y: auto;
   padding: 1rem 0;
+
+  @media (max-width: 480px) {
+    align-items: flex-start;
+  }
 `;
 
 const ModalContainer = styled.div`
@@ -557,12 +561,14 @@ const ModalContainer = styled.div`
     margin: 0 0.5rem;
     padding: 1.5rem 1rem;
     max-height: 85vh; /* Slightly smaller on mobile to ensure it doesn't overflow */
+    margin-top: 1rem;
   }
 
   @media (max-width: 360px) {
     padding: 1.2rem 0.8rem;
     width: 100%;
     margin: 0 0.3rem;
+    margin-top: 0.5rem;
   }
   
   @keyframes slideIn {


### PR DESCRIPTION
## Summary
- fix responsive layout for AuthModal on mobile screens
- align modal at top on small devices and add spacing

## Testing
- `npm run lint`
- `npm test -- -w 1` *(fails: 5 failed, 2 passed)*
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
- `npm run build`