### PR TITLE
[Dashboard] Add loading skeletons

### DIFF
--- a/src/components/Dashboard/ProjectNotes.js
+++ b/src/components/Dashboard/ProjectNotes.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
+import LoadingSkeleton from '../Common/LoadingSkeleton';
 import { FaRegStickyNote, FaMicrophone, FaPaperPlane, FaStop, FaTrash } from 'react-icons/fa';
 import { collection, addDoc, getDocs, query, where, orderBy, serverTimestamp, deleteDoc, doc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
@@ -295,10 +296,19 @@ const ProjectNotes = ({ projectId, projectName }) => {
       </NotesForm>
       
       {isLoading && notes.length === 0 ? (
-        <LoadingContainer>
-          <LoadingSpinner />
-          <p>{t('notes.loading', 'Loading notes...')}</p>
-        </LoadingContainer>
+        <NotesList aria-hidden="true">
+          {Array.from({ length: 3 }).map((_, idx) => (
+            <NoteItemSkeleton key={idx}>
+              <SkeletonHeader>
+                <LoadingSkeleton width="40%" height="0.9rem" />
+              </SkeletonHeader>
+              <SkeletonBody>
+                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.4rem' }} />
+                <LoadingSkeleton height="0.8rem" />
+              </SkeletonBody>
+            </NoteItemSkeleton>
+          ))}
+        </NotesList>
       ) : notes.length === 0 ? (
         <EmptyState>
           <p>{t('notes.empty', 'No notes yet. Add your first note above.')}</p>
@@ -488,29 +498,6 @@ const StopButton = styled.button`
   }
 `;
 
-const LoadingContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  flex: 1;
-  color: #fff;
-`;
-
-const LoadingSpinner = styled.div`
-  width: 30px;
-  height: 30px;
-  border: 3px solid rgba(205, 62, 253, 0.3);
-  border-top: 3px solid #cd3efd;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-bottom: 1rem;
-  
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-`;
 
 const EmptyState = styled.div`
   display: flex;
@@ -521,6 +508,7 @@ const EmptyState = styled.div`
   text-align: center;
   color: rgba(255, 255, 255, 0.6);
 `;
+
 
 const NotesList = styled.div`
   flex: 1;
@@ -592,6 +580,20 @@ const AudioContainer = styled.div`
     border-radius: 18px;
     background: rgba(33, 150, 243, 0.1);
   }
+`;
+
+const NoteItemSkeleton = styled(NoteItem)`
+  border-left-color: rgba(205, 62, 253, 0.1);
+`;
+
+const SkeletonHeader = styled(NoteHeader)`
+  align-items: center;
+`;
+
+const SkeletonBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 `;
 
 export default ProjectNotes;

--- a/src/components/Dashboard/ProjectsPanel.js
+++ b/src/components/Dashboard/ProjectsPanel.js
@@ -6,6 +6,7 @@ import { db } from '../../firebase';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
 import useFirebaseListener from '../../hooks/useFirebaseListener';
+import LoadingSkeleton from '../Common/LoadingSkeleton';
 import {
   Card,
   DashboardTitle,
@@ -167,10 +168,21 @@ const ProjectsPanel = () => {
       </PanelHeader>
       
       {isLoading ? (
-        <LoadingContainer>
-          <LoadingSpinner />
-          <p>{t('projects.loading', 'Loading projects...')}</p>
-        </LoadingContainer>
+        <ProjectsContainer isGridView={isGridView} aria-hidden="true">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <ProjectCardSkeleton key={idx} isGridView={isGridView}>
+              <SkeletonHeader>
+                <LoadingSkeleton width="60%" height="1.2rem" />
+                <LoadingSkeleton width="30%" height="1rem" />
+              </SkeletonHeader>
+              <SkeletonBody>
+                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.5rem' }} />
+                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.5rem' }} />
+                <LoadingSkeleton height="0.8rem" />
+              </SkeletonBody>
+            </ProjectCardSkeleton>
+          ))}
+        </ProjectsContainer>
       ) : projects.length === 0 ? (
         <EmptyState>
           <h3>{t('projects.noProjects', 'No projects found')}</h3>
@@ -317,29 +329,8 @@ const Select = styled.select`
   }
 `;
 
-const LoadingContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 300px;
-  color: #fff;
-`;
 
-const LoadingSpinner = styled.div`
-  width: 40px;
-  height: 40px;
-  border: 3px solid rgba(205, 62, 253, 0.3);
-  border-top: 3px solid #cd3efd;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  margin-bottom: 1rem;
-  
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-`;
+
 
 const EmptyState = styled(SharedEmptyState)`
   height: 300px;
@@ -472,6 +463,20 @@ const ActionButton = styled(SecondaryButton)`
   background: rgba(205, 62, 253, 0.1);
   padding: 0.4rem 0.6rem;
   font-size: 0.8rem;
+`;
+
+const ProjectCardSkeleton = styled(ProjectCard)`
+  pointer-events: none;
+`;
+
+const SkeletonHeader = styled(ProjectHeader)`
+  align-items: center;
+`;
+
+const SkeletonBody = styled(ProjectDetails)`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 `;
 
 export default ProjectsPanel;


### PR DESCRIPTION
## Summary
- create loading skeleton layout in ProjectsPanel
- show skeleton for ProjectNotes while notes load

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
