### PR TITLE
[Dashboard] Add mobile sidebar backdrop

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -160,12 +160,21 @@ const Dashboard = () => {
         setSidebarOpen(true);
       }
     };
-    
+
     handleResize();
     window.addEventListener('resize', handleResize);
-    
+
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  // Prevent background scrolling when sidebar is open on mobile
+  useEffect(() => {
+    if (mobileView && sidebarOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  }, [mobileView, sidebarOpen]);
   
   const toggleSidebar = () => {
     setSidebarOpen(!sidebarOpen);
@@ -488,6 +497,7 @@ const SidebarBackdrop = styled.div`
   bottom: 0;
   background: rgba(0, 0, 0, 0.5);
   z-index: 1000;
+  cursor: pointer;
 
   @media (max-width: 768px) {
     top: 60px;


### PR DESCRIPTION
## Summary
- implement overlay to close mobile sidebar
- prevent scrolling when sidebar open on mobile

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
