### PR TITLE
[Dashboard] Add translation keys for TasksPanel

### DIFF
--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -234,7 +234,19 @@
     "quickActions": "إجراءات سريعة",
     "newProject": "مشروع جديد",
     "logTime": "تسجيل الوقت",
-    "uploadFile": "رفع ملف"
+    "uploadFile": "رفع ملف",
+    "tasks": {
+      "title": "المهام والإنجازات",
+      "actions": {
+        "addTask": "إضافة مهمة"
+      },
+      "todo": "قائمة المهام",
+      "emptyTodo": "لا توجد مهام حالية",
+      "doing": "جاري العمل",
+      "emptyDoing": "لا توجد مهام قيد التنفيذ",
+      "done": "منجز",
+      "emptyDone": "لا توجد مهام منجزة"
+    }
   },
   
   "files": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -234,7 +234,19 @@
     "quickActions": "Quick Actions",
     "newProject": "New Project",
     "logTime": "Log Time",
-    "uploadFile": "Upload File"
+    "uploadFile": "Upload File",
+    "tasks": {
+      "title": "Tasks & Milestones",
+      "actions": {
+        "addTask": "Add Task"
+      },
+      "todo": "To Do",
+      "emptyTodo": "No tasks to do",
+      "doing": "In Progress",
+      "emptyDoing": "No tasks in progress",
+      "done": "Done",
+      "emptyDone": "No completed tasks"
+    }
   },
   
   "files": {


### PR DESCRIPTION
## Summary
- add English and Arabic translation strings for TasksPanel

## Testing
- `jq '.' src/locales/en/translation.json`
- `jq '.' src/locales/ar/translation.json`
