### PR TITLE
[Dashboard] Add persistent tasks hook

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -18,6 +18,7 @@ DevFolio is a responsive website built for a solo developer offering software de
   - Email/Password authentication
   - Phone number verification
 - **User Dashboard**: Personalized dashboard for authenticated users
+  - Tasks are loaded using the `useTasks` hook which syncs data from Firestore and stores a local copy in `localStorage` for offline access.
 - **SEO Optimized**: Comprehensive SEO implementation including:
   - Semantic HTML structure with proper heading hierarchy (h1-h6)
   - Descriptive alt text for all images and icons

--- a/src/components/Dashboard/TasksPanel.js
+++ b/src/components/Dashboard/TasksPanel.js
@@ -27,74 +27,22 @@ import {
   EmptyColumnMessage,
   AddTaskButton
 } from '../../styles/dashboardStyles';
-
-// Mock tasks data
-const MOCK_TASKS = [
-  {
-    id: '1',
-    title: 'Design homepage mockup',
-    description: 'Create wireframes and high-fidelity mockups for the landing page',
-    status: 'todo',
-    priority: 'high',
-    dueDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000), // 3 days from now
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
-    assignedToName: 'You',
-    isClientTask: false
-  },
-  {
-    id: '2',
-    title: 'Implement authentication system',
-    description: 'Set up user registration, login, and password reset functionality',
-    status: 'doing',
-    priority: 'high',
-    dueDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000), // 5 days from now
-    createdAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000), // 4 days ago
-    assignedToName: 'You',
-    isClientTask: false
-  },
-  {
-    id: '3',
-    title: 'Create responsive navigation',
-    description: 'Build a responsive navbar with mobile menu',
-    status: 'done',
-    priority: 'medium',
-    dueDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
-    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
-    completedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
-    assignedToName: 'You',
-    isClientTask: false
-  },
-  {
-    id: '4',
-    title: 'Provide content for About section',
-    description: 'Write bio and list of services for the About page',
-    status: 'todo',
-    priority: 'low',
-    dueDate: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000), // 10 days from now
-    createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
-    assignedToName: 'Client',
-    isClientTask: true
-  },
-  {
-    id: '5',
-    title: 'Set up contact form',
-    description: 'Create form with validation and email notification',
-    status: 'doing',
-    priority: 'medium',
-    dueDate: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000), // 4 days from now
-    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
-    assignedToName: 'You',
-    isClientTask: false
-  }
-];
+import useTasks from '../../hooks/useTasks';
 
 const TasksPanel = () => {
   const { t } = useTranslation();
-  
+  const tasks = useTasks();
+
+  const parseDate = (d) => {
+    if (!d) return null;
+    if (typeof d.toDate === 'function') return d.toDate();
+    return new Date(d);
+  };
+
   // Filter tasks by status
-  const todoTasks = MOCK_TASKS.filter(task => task.status === 'todo');
-  const doingTasks = MOCK_TASKS.filter(task => task.status === 'doing');
-  const doneTasks = MOCK_TASKS.filter(task => task.status === 'done');
+  const todoTasks = tasks.filter(task => task.status === 'todo');
+  const doingTasks = tasks.filter(task => task.status === 'doing');
+  const doneTasks = tasks.filter(task => task.status === 'done');
 
   return (
     <TasksPanelContainer>
@@ -136,7 +84,7 @@ const TasksPanel = () => {
                 <TaskMeta>
                   <TaskMetaItem>
                     <FaCalendarAlt />
-                    <span>{task.dueDate.toLocaleDateString()}</span>
+                    <span>{parseDate(task.dueDate)?.toLocaleDateString()}</span>
                   </TaskMetaItem>
                   <TaskMetaItem>
                     <FaUserAlt />
@@ -177,7 +125,7 @@ const TasksPanel = () => {
                 <TaskMeta>
                   <TaskMetaItem>
                     <FaCalendarAlt />
-                    <span>{task.dueDate.toLocaleDateString()}</span>
+                    <span>{parseDate(task.dueDate)?.toLocaleDateString()}</span>
                   </TaskMetaItem>
                   <TaskMetaItem>
                     <FaUserAlt />
@@ -218,7 +166,7 @@ const TasksPanel = () => {
                 <TaskMeta>
                   <TaskMetaItem>
                     <FaCalendarAlt />
-                    <span>{task.dueDate.toLocaleDateString()}</span>
+                    <span>{parseDate(task.dueDate)?.toLocaleDateString()}</span>
                   </TaskMetaItem>
                   <TaskMetaItem>
                     <FaUserAlt />

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -48,3 +48,24 @@ The hook uses `useEffect` and `useRef` internally to track the unsubscribe funct
 ### Testing
 
 When testing components that use Firebase listeners, you can use the mock Firebase implementation in `src/__mocks__/firebase.js` along with this hook to ensure proper testing in offline environments.
+
+## useTasks
+
+The `useTasks` hook provides persistent task loading for the dashboard. It reads tasks from Firestore when available and falls back to `localStorage` for offline usage. The hook automatically keeps `localStorage` in sync with updates from Firestore.
+
+### Usage
+
+```javascript
+import useTasks from '../hooks/useTasks';
+
+function TasksPanel() {
+  const tasks = useTasks();
+
+  // Render tasks
+}
+```
+
+### Benefits
+
+1. **Data Persistence**: Tasks remain available offline via `localStorage`.
+2. **Realtime Updates**: When connected to Firestore, task changes update automatically.

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+
+const STORAGE_KEY = 'tasks';
+
+/**
+ * Custom hook to load tasks from Firestore with localStorage fallback.
+ * It listens to the "tasks" collection and keeps localStorage in sync.
+ */
+export default function useTasks() {
+  const [tasks, setTasks] = useState([]);
+
+  // Load tasks from localStorage on first render
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setTasks(parsed);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to parse stored tasks', err);
+    }
+  }, []);
+
+  // Subscribe to Firestore tasks collection when available
+  useEffect(() => {
+    if (!db || typeof collection !== 'function') return undefined;
+
+    try {
+      const unsubscribe = onSnapshot(collection(db, 'tasks'), (snapshot) => {
+        const fetched = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        setTasks(fetched);
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(fetched));
+        } catch (err) {
+          console.error('Failed to store tasks', err);
+        }
+      });
+      return unsubscribe;
+    } catch (err) {
+      console.error('Failed to subscribe to tasks collection', err);
+      return undefined;
+    }
+  }, []);
+
+  return tasks;
+}
+


### PR DESCRIPTION
## Summary
- implement `useTasks` hook for loading tasks from Firestore with localStorage fallback
- use new hook in `TasksPanel`
- document `useTasks` in hooks README and project docs

## Testing
- `npm run lint`
- `npm test` *(fails: You cannot render a <Router> inside another <Router>)*
- `node src/__tests__/runTests.js`
