### PR TITLE
[Dashboard] Standardize panel card backgrounds

### DIFF
--- a/src/components/Dashboard/FileCard.js
+++ b/src/components/Dashboard/FileCard.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
+import { Card as BaseCard } from '../../styles/dashboardStyles';
 import { useTranslation } from 'react-i18next';
 import { 
   FaFile, FaFileImage, FaFilePdf, FaFileWord, FaFileCode, 
@@ -132,13 +133,8 @@ const FileCard = ({ file }) => {
 };
 
 // Styled Components
-const Card = styled.div`
-  background: white;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
-  overflow: hidden;
+const Card = styled(BaseCard)`
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
   position: relative;
   text-align: ${props => props.isRTL ? 'right' : 'left'};
   display: flex;
@@ -147,7 +143,6 @@ const Card = styled.div`
   
   &:hover {
     transform: translateY(-5px);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
   }
   
   &:after {

--- a/src/components/Dashboard/FilesPanel.js
+++ b/src/components/Dashboard/FilesPanel.js
@@ -5,6 +5,7 @@ import { FaUpload, FaFilter, FaSearch, FaTags, FaDownload, FaEye, FaTrash, FaHis
 import FileCard from './FileCard';
 import Button from '../Common/Button';
 import {
+  Card,
   PanelContainer,
   PanelHeader,
   DashboardTitle,
@@ -202,11 +203,7 @@ const FilesPanel = () => {
 };
 
 // Using the shared PanelContainer component
-const FilesPanelContainer = styled(PanelContainer)`
-  background-color: #fff;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  overflow: hidden;
+const FilesPanelContainer = styled(Card)`
   direction: ${props => props.isRTL ? 'rtl' : 'ltr'};
 `;
 
@@ -225,7 +222,7 @@ const FilesPanelHeader = styled(PanelHeader)`
 
 // Using the shared DashboardTitle component
 const PanelTitle = styled(DashboardTitle)`
-  color: #333;
+  color: #fff;
 `;
 
 // Using the shared PrimaryButton component
@@ -491,13 +488,11 @@ const FilesGrid = styled.div`
   position: relative;
   z-index: 1;
   background: none !important;
-  
+
   /* Add staggered animation for file cards */
   & > div {
     animation: fadeInUp 0.5s ease-out forwards;
     opacity: 0;
-    background-color: white !important;
-    background-image: none !important;
   }
   
   & > div:nth-child(1) { animation-delay: 0.1s; }

--- a/src/components/Dashboard/FormsPanel.js
+++ b/src/components/Dashboard/FormsPanel.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled, { css, keyframes } from 'styled-components';
+import { Card } from '../../styles/dashboardStyles';
 import { useTranslation } from 'react-i18next';
 import { 
   FaCommentAlt, FaClipboardList, FaEdit, FaEye, 
@@ -335,7 +336,7 @@ const FormsPanel = () => {
 };
 
 // Styled components
-const FormsPanelContainer = styled.div`
+const FormsPanelContainer = styled(Card)`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -503,12 +504,9 @@ const FormsGrid = styled.div`
   }
 `;
 
-const FormCard = styled.div`
+const FormCard = styled(Card)`
   display: flex;
   flex-direction: column;
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
   padding: 1.5rem;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   animation: ${fadeIn} 0.5s ease-in-out forwards, ${slideUp} 0.5s ease-in-out forwards;
@@ -696,24 +694,18 @@ const FormActions = styled.div`
   & > *:nth-child(3) { transition-delay: 0.15s; }
 `;
 
-const NewFormContainer = styled.div`
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
+const NewFormContainer = styled(Card)`
   margin-bottom: 2rem;
   animation: ${fadeIn} 0.3s ease-in-out, ${slideUp} 0.3s ease-in-out;
 `;
 
-const EmptyState = styled.div`
+const EmptyState = styled(Card)`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
   padding: 3rem 1rem;
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.05);
   animation: ${fadeIn} 0.5s ease-in-out, ${slideUp} 0.5s ease-in-out;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
@@ -863,12 +855,9 @@ const FeaturesGrid = styled.div`
   }
 `;
 
-const FeatureCard = styled.div`
+const FeatureCard = styled(Card)`
   display: flex;
   align-items: flex-start;
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
   padding: 1.5rem;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   animation: ${fadeIn} 0.5s ease-in-out, ${slideUp} 0.5s ease-in-out;

--- a/src/components/Dashboard/TaskCard.js
+++ b/src/components/Dashboard/TaskCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Card as BaseCard } from '../../styles/dashboardStyles';
 import { useTranslation } from 'react-i18next';
 import { 
   FaCalendarAlt, 
@@ -205,14 +206,10 @@ const TaskCard = ({
 };
 
 // Styled Components
-const Card = styled.div`
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+const Card = styled(BaseCard)`
   padding: 1rem;
   margin-bottom: 1rem;
   cursor: pointer;
-  transition: all 0.2s ease;
   direction: ${props => props.isRTL ? 'rtl' : 'ltr'};
   text-align: ${props => props.isRTL ? 'right' : 'left'};
   border-left: 4px solid ${props => getPriorityColor(props.priority)};


### PR DESCRIPTION
## Summary
- switch FilesPanelContainer to use gradient Card styling
- style FileCard and TaskCard with dark gradient
- update FormsPanel containers and cards with gradient backgrounds
- run lint, build and tests

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Error initializing Firebase services)*
- `npm run build`
- `npm run test:responsive --silent`