### PR TITLE
[Dashboard] Apply dark gradient styling to cards

### DIFF
--- a/src/components/Dashboard/FileCard.js
+++ b/src/components/Dashboard/FileCard.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { Card as BaseCard } from '../../styles/dashboardStyles';
+import { colors } from '../../styles/GlobalTheme';
 import { useTranslation } from 'react-i18next';
 import { 
   FaFile, FaFileImage, FaFilePdf, FaFileWord, FaFileCode, 
@@ -280,7 +281,7 @@ const FilePreview = styled.div`
   cursor: pointer;
   position: relative;
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  background-color: #f9f9f9;
+  background: ${colors.background.card};
   
   &:before {
     content: '';
@@ -332,7 +333,7 @@ const IconWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(145deg, #f9f9f9, #f0f0f0);
+  background: ${colors.gradients.card};
   position: relative;
   overflow: hidden;
   
@@ -381,7 +382,7 @@ const CardFooter = styled.div`
   flex-direction: column;
   gap: 0.75rem;
   padding: 1.25rem 1.5rem 1.5rem;
-  background: white;
+  background: ${colors.background.card};
   position: relative;
   z-index: 1;
 `;

--- a/src/components/Dashboard/FilesPanel.js
+++ b/src/components/Dashboard/FilesPanel.js
@@ -16,6 +16,7 @@ import {
   FlexContainer,
   Badge
 } from '../../styles/dashboardStyles';
+import { colors } from '../../styles/GlobalTheme';
 
 const FilesPanel = () => {
   const { t, i18n } = useTranslation();
@@ -211,8 +212,8 @@ const FilesPanelContainer = styled(Card)`
 // Using the shared PanelHeader component
 const FilesPanelHeader = styled(PanelHeader)`
   padding: 1.75rem 2rem;
-  border-bottom: 1px solid #f0f0f0;
-  background-color: #ffffff;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: ${colors.gradients.card};
   
   @media (max-width: 768px) {
     flex-direction: column;
@@ -265,8 +266,8 @@ const FilesToolbar = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 1.25rem 2rem;
-  border-bottom: 1px solid #f0f0f0;
-  background-color: #fafafa;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: ${colors.gradients.card};
   
   @media (max-width: 768px) {
     flex-direction: column;
@@ -278,8 +279,8 @@ const FilesToolbar = styled.div`
 const SearchBar = styled.div`
   display: flex;
   align-items: center;
-  background-color: white;
-  border: 1px solid #e0e0e0;
+  background: ${colors.background.card};
+  border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   padding: 0.6rem 1rem;
   width: 100%;
@@ -357,12 +358,12 @@ const FilterButton = styled.button`
   transition: all 0.3s ease;
   font-size: 0.8rem;
   padding: 0.5rem 0.75rem;
-  background-color: ${props => props.active ? '#513a52' : '#f7f9fc'};
-  color: ${props => props.active ? 'white' : '#513a52'};
+  background: ${props => props.active ? colors.accent.secondary : colors.background.card};
+  color: ${colors.text.primary};
   border: none;
   
   &:hover {
-    background-color: ${props => props.active ? '#3d2c3d' : '#edf1f7'};
+    background: ${props => props.active ? colors.accent.primary : colors.background.hover};
   }
 `;
 
@@ -382,15 +383,15 @@ const DropdownItem = styled.div`
   font-size: 0.9rem;
   cursor: pointer;
   transition: all 0.2s ease;
-  color: ${props => props.active ? '#4A6FA5' : '#666'};
-  background-color: ${props => props.active ? '#EBF2FA' : 'white'};
+  color: ${props => props.active ? colors.accent.primary : colors.text.secondary};
+  background: ${colors.background.card};
   
   &:hover {
-    background-color: ${props => props.active ? '#D9E6F7' : '#f5f5f5'};
+    background: ${colors.background.hover};
   }
   
   &:not(:last-child) {
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   }
 `;
 
@@ -412,12 +413,12 @@ const TagButton = styled.button`
   transition: all 0.3s ease;
   font-size: 0.8rem;
   padding: 0.5rem 0.75rem;
-  background-color: ${props => props.active ? '#513a52' : '#f7f9fc'};
-  color: ${props => props.active ? 'white' : '#513a52'};
+  background: ${props => props.active ? colors.accent.secondary : colors.background.card};
+  color: ${colors.text.primary};
   border: none;
   
   &:hover {
-    background-color: ${props => props.active ? '#3d2c3d' : '#edf1f7'};
+    background: ${props => props.active ? colors.accent.primary : colors.background.hover};
   }
 `;
 
@@ -457,7 +458,7 @@ const DropMessage = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background-color: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.1);
   z-index: 10;
   border-radius: 12px;
   animation: pulse 2s infinite;
@@ -534,10 +535,10 @@ const NoFilesMessage = styled.div`
   align-items: center;
   justify-content: center;
   padding: 4rem 2rem;
-  background-color: #f8f9fa;
+  background: ${colors.background.card};
   border-radius: 12px;
   text-align: center;
-  border: 1px dashed #e0e0e0;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
   grid-column: 1 / -1;
   
   p {

--- a/src/components/Dashboard/FormsPanel.js
+++ b/src/components/Dashboard/FormsPanel.js
@@ -363,14 +363,14 @@ const SearchAndSortContainer = styled.div`
 const SearchBar = styled.div`
   display: flex;
   align-items: center;
-  background-color: white;
+  background: ${colors.background.card};
   border-radius: 8px;
   padding: 0.5rem 1rem;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 350px;
   transition: all 0.3s ease;
-  border: 1px solid transparent;
+  border: 1px solid rgba(255, 255, 255, 0.05);
   
   &:focus-within {
     box-shadow: 0 3px 15px rgba(130, 161, 191, 0.15);
@@ -450,7 +450,7 @@ const FormCard = styled(Card)`
   &:hover {
     transform: translateY(-5px) scale(1.02);
     box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
-    background-color: #fafafa;
+    background: ${colors.background.hover};
   }
   
   &:active {


### PR DESCRIPTION
## Summary
- standardize dashboard card styling with dark gradients
- adjust file and form panels to use GlobalTheme colors
- refine file card backgrounds

## Testing
- `npm run lint`
- `npm test --silent` *(fails: app initialization)*
- `npm run build`