### PR TITLE
[Dashboard] Fix collapse icon orientation in RTL

### DIFF
--- a/src/components/Dashboard/Sidebar.js
+++ b/src/components/Dashboard/Sidebar.js
@@ -116,7 +116,9 @@ const Sidebar = ({ collapsed = false, onToggleCollapse }) => {
         aria-label={collapsed ? t('dashboard.sidebar.expand', 'Expand Sidebar') : t('dashboard.sidebar.collapse', 'Collapse Sidebar')}
         isRTL={isRTL}
       >
-        {collapsed ? <FaAngleDoubleRight /> : <FaAngleDoubleLeft />}
+        {collapsed
+          ? (isRTL ? <FaAngleDoubleLeft /> : <FaAngleDoubleRight />)
+          : (isRTL ? <FaAngleDoubleRight /> : <FaAngleDoubleLeft />)}
       </CollapseButton>
 
       <NavMenu role="menu" collapsed={collapsed}>


### PR DESCRIPTION
## Summary
- fix sidebar collapse/expand icon orientation to support RTL

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
