### PR TITLE
[UI] Improve mobile responsiveness

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1042,6 +1042,11 @@ const BotMessageBubble = styled.div`
   max-width: 80%;
   margin-bottom: 1rem;
   line-height: 1.5;
+
+  @media (max-width: 480px) {
+    max-width: 90%;
+    padding: 0.8rem;
+  }
 `;
 
 const ChatbotInput = styled.div`

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -87,6 +87,10 @@ const HeroSection = styled.section`
   @media (max-width: 768px) {
     padding: 4rem 0 3rem; /* Reduced top padding for mobile */
   }
+
+  @media (max-width: 480px) {
+    padding: 3rem 0 2rem; /* Further reduce padding on very small screens */
+  }
 `;
 
 const HeroContainer = styled.div`
@@ -150,7 +154,7 @@ const HeroHeading = styled.h1`
   }
 
   @media (max-width: 480px) {
-    font-size: 1.9rem;
+    font-size: 1.8rem;
     margin-bottom: 0.5rem;
   }
 `;

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -227,6 +227,10 @@ const FooterDescription = styled.p`
   font-size: 1rem;
   max-width: 400px;
   text-align: ${props => props.isRTL ? 'right' : 'left'};
+
+  @media (max-width: 576px) {
+    max-width: 100%;
+  }
 `;
 
 const FooterSlogan = styled.p`
@@ -245,6 +249,10 @@ const FooterSlogan = styled.p`
   
   @media (max-width: 768px) {
     font-size: 1.1rem;
+  }
+
+  @media (max-width: 576px) {
+    max-width: 100%;
   }
 `;
 
@@ -377,6 +385,10 @@ const FooterDivider = styled.div`
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
   margin: 0 auto;
   width: 80%;
+
+  @media (max-width: 576px) {
+    width: 90%;
+  }
 `;
 
 const FooterBottom = styled.div`


### PR DESCRIPTION
## Summary
- tweak hero section padding and heading size for very small screens
- adjust footer spacing and text width on mobile
- ensure chatbot message bubbles scale better on small devices

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
- `npm run build`