### PR TITLE
[Dashboard] Add skeleton loaders

### DIFF
--- a/src/components/Common/SkeletonLoader.js
+++ b/src/components/Common/SkeletonLoader.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+import { shimmer } from '../../styles/animations';
+import { colors } from '../../styles/GlobalTheme';
+
+/**
+ * SkeletonLoader shows a shimmering placeholder while content loads.
+ * width and height can be customized. Set circle to true for circular shapes.
+ */
+const Skeleton = styled.div`
+  display: inline-block;
+  width: ${({ width }) => width || '100%'};
+  height: ${({ height }) => height || '1rem'};
+  border-radius: ${({ circle }) => (circle ? '50%' : '4px')};
+  background-color: ${colors.background.card};
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.15) 40px,
+    rgba(255, 255, 255, 0.05) 80px
+  );
+  background-size: 600px 100%;
+  animation: ${shimmer} 1.2s ease-in-out infinite;
+`;
+
+const SkeletonLoader = ({ width, height, circle, style }) => (
+  <Skeleton width={width} height={height} circle={circle} style={style} />
+);
+
+export default SkeletonLoader;

--- a/src/components/Dashboard/FilesPanel.js
+++ b/src/components/Dashboard/FilesPanel.js
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { FaUpload, FaFilter, FaSearch, FaTags, FaDownload, FaEye, FaTrash, FaHistory } from 'react-icons/fa';
 import FileCard from './FileCard';
 import Button from '../Common/Button';
+import SkeletonLoader from '../Common/SkeletonLoader';
 import {
   Card,
   PanelContainer,
@@ -24,6 +25,12 @@ const FilesPanel = () => {
   const fileInputRef = useRef(null);
   const [dragActive, setDragActive] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
   
   // Mock data for files
   const mockFiles = [
@@ -189,7 +196,17 @@ const FilesPanel = () => {
         
         {/* Files Grid */}
         <FilesGrid>
-          {filteredFiles.length > 0 ? (
+          {isLoading ? (
+            Array.from({ length: 4 }).map((_, idx) => (
+              <FileSkeleton key={idx}>
+                <SkeletonLoader height="140px" />
+                <SkeletonInfo>
+                  <SkeletonLoader width="70%" height="0.8rem" style={{ marginBottom: '0.5rem' }} />
+                  <SkeletonLoader width="40%" height="0.8rem" />
+                </SkeletonInfo>
+              </FileSkeleton>
+            ))
+          ) : filteredFiles.length > 0 ? (
             filteredFiles.map(file => (
               <FileCard key={file.id} file={file} />
             ))
@@ -546,6 +563,18 @@ const NoFilesMessage = styled.div`
     font-size: 1.1rem;
     margin-bottom: 1.5rem;
   }
+`;
+
+const FileSkeleton = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+const SkeletonInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 `;
 
 export default FilesPanel;

--- a/src/components/Dashboard/ProjectNotes.js
+++ b/src/components/Dashboard/ProjectNotes.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import LoadingSkeleton from '../Common/LoadingSkeleton';
+import SkeletonLoader from '../Common/SkeletonLoader';
 import { FaRegStickyNote, FaMicrophone, FaPaperPlane, FaStop, FaTrash } from 'react-icons/fa';
 import { collection, addDoc, getDocs, query, where, orderBy, serverTimestamp, deleteDoc, doc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage';
@@ -300,11 +300,11 @@ const ProjectNotes = ({ projectId, projectName }) => {
           {Array.from({ length: 3 }).map((_, idx) => (
             <NoteItemSkeleton key={idx}>
               <SkeletonHeader>
-                <LoadingSkeleton width="40%" height="0.9rem" />
+                <SkeletonLoader width="40%" height="0.9rem" />
               </SkeletonHeader>
               <SkeletonBody>
-                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.4rem' }} />
-                <LoadingSkeleton height="0.8rem" />
+                <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.4rem' }} />
+                <SkeletonLoader height="0.8rem" />
               </SkeletonBody>
             </NoteItemSkeleton>
           ))}

--- a/src/components/Dashboard/ProjectsPanel.js
+++ b/src/components/Dashboard/ProjectsPanel.js
@@ -6,7 +6,7 @@ import { db } from '../../firebase';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTranslation } from 'react-i18next';
 import useFirebaseListener from '../../hooks/useFirebaseListener';
-import LoadingSkeleton from '../Common/LoadingSkeleton';
+import SkeletonLoader from '../Common/SkeletonLoader';
 import {
   PanelContainer,
   PanelHeader,
@@ -173,13 +173,13 @@ const ProjectsPanel = () => {
           {Array.from({ length: 4 }).map((_, idx) => (
             <ProjectCardSkeleton key={idx} isGridView={isGridView}>
               <SkeletonHeader>
-                <LoadingSkeleton width="60%" height="1.2rem" />
-                <LoadingSkeleton width="30%" height="1rem" />
+                <SkeletonLoader width="60%" height="1.2rem" />
+                <SkeletonLoader width="30%" height="1rem" />
               </SkeletonHeader>
               <SkeletonBody>
-                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.5rem' }} />
-                <LoadingSkeleton height="0.8rem" style={{ marginBottom: '0.5rem' }} />
-                <LoadingSkeleton height="0.8rem" />
+                <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.5rem' }} />
+                <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.5rem' }} />
+                <SkeletonLoader height="0.8rem" />
               </SkeletonBody>
             </ProjectCardSkeleton>
           ))}

--- a/src/components/Dashboard/TasksPanel.js
+++ b/src/components/Dashboard/TasksPanel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { 
@@ -21,10 +21,17 @@ import {
 } from '../../styles/GlobalComponents';
 import { colors, spacing, borderRadius, shadows, mixins, transitions, typography } from '../../styles/GlobalTheme';
 import useTasks from '../../hooks/useTasks';
+import SkeletonLoader from '../Common/SkeletonLoader';
 
 const TasksPanel = () => {
   const { t } = useTranslation();
   const tasks = useTasks();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
 
   const parseDate = (d) => {
     if (!d) return null;
@@ -65,7 +72,18 @@ const TasksPanel = () => {
           </ColumnHeader>
           
           <ColumnContent>
-            {todoTasks.map(task => (
+            {isLoading ? (
+              Array.from({ length: 2 }).map((_, idx) => (
+                <TaskCard key={idx}>
+                  <TaskCardHeader>
+                    <SkeletonLoader width="60%" height="0.9rem" />
+                    <SkeletonLoader width="30%" height="0.8rem" />
+                  </TaskCardHeader>
+                  <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.3rem' }} />
+                  <SkeletonLoader height="0.8rem" />
+                </TaskCard>
+              ))
+            ) : todoTasks.map(task => (
               <TaskCard key={task.id}>
                 <TaskCardHeader>
                   <TaskTitle>{task.title}</TaskTitle>
@@ -86,8 +104,8 @@ const TasksPanel = () => {
                 </TaskMeta>
               </TaskCard>
             ))}
-            
-            {todoTasks.length === 0 && (
+
+            {!isLoading && todoTasks.length === 0 && (
               <EmptyColumnState>
                 {t('dashboard.tasks.emptyTodo', 'No tasks to do')}
               </EmptyColumnState>
@@ -106,7 +124,18 @@ const TasksPanel = () => {
           </ColumnHeader>
           
           <ColumnContent>
-            {doingTasks.map(task => (
+            {isLoading ? (
+              Array.from({ length: 2 }).map((_, idx) => (
+                <TaskCard key={idx}>
+                  <TaskCardHeader>
+                    <SkeletonLoader width="60%" height="0.9rem" />
+                    <SkeletonLoader width="30%" height="0.8rem" />
+                  </TaskCardHeader>
+                  <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.3rem' }} />
+                  <SkeletonLoader height="0.8rem" />
+                </TaskCard>
+              ))
+            ) : doingTasks.map(task => (
               <TaskCard key={task.id}>
                 <TaskCardHeader>
                   <TaskTitle>{task.title}</TaskTitle>
@@ -127,8 +156,8 @@ const TasksPanel = () => {
                 </TaskMeta>
               </TaskCard>
             ))}
-            
-            {doingTasks.length === 0 && (
+
+            {!isLoading && doingTasks.length === 0 && (
               <EmptyColumnState>
                 {t('dashboard.tasks.emptyDoing', 'No tasks in progress')}
               </EmptyColumnState>
@@ -147,7 +176,18 @@ const TasksPanel = () => {
           </ColumnHeader>
           
           <ColumnContent>
-            {doneTasks.map(task => (
+            {isLoading ? (
+              Array.from({ length: 2 }).map((_, idx) => (
+                <TaskCard key={idx}>
+                  <TaskCardHeader>
+                    <SkeletonLoader width="60%" height="0.9rem" />
+                    <SkeletonLoader width="30%" height="0.8rem" />
+                  </TaskCardHeader>
+                  <SkeletonLoader height="0.8rem" style={{ marginBottom: '0.3rem' }} />
+                  <SkeletonLoader height="0.8rem" />
+                </TaskCard>
+              ))
+            ) : doneTasks.map(task => (
               <TaskCard key={task.id}>
                 <TaskCardHeader>
                   <TaskTitle>{task.title}</TaskTitle>
@@ -168,8 +208,8 @@ const TasksPanel = () => {
                 </TaskMeta>
               </TaskCard>
             ))}
-            
-            {doneTasks.length === 0 && (
+
+            {!isLoading && doneTasks.length === 0 && (
               <EmptyColumnState>
                 {t('dashboard.tasks.emptyDone', 'No completed tasks')}
               </EmptyColumnState>


### PR DESCRIPTION
## Summary
- create `SkeletonLoader` component using shimmer animation
- replace old `LoadingSkeleton` usage with new loader
- show skeleton states while data loads in FilesPanel and TasksPanel
- keep existing panels consistent with new loader

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
