### PR TITLE
[Hero] Implement lazy load for hero image

### DIFF
--- a/src/components/Common/LazyImage.js
+++ b/src/components/Common/LazyImage.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const LazyImage = ({ src, alt, ...rest }) => {
+  const [loadedSrc, setLoadedSrc] = useState(null);
+  const imgRef = useRef(null);
+
+  useEffect(() => {
+    let observer;
+    if (imgRef.current && !loadedSrc) {
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setLoadedSrc(src);
+              observer.disconnect();
+            }
+          });
+        },
+        { rootMargin: '100px' }
+      );
+      observer.observe(imgRef.current);
+    }
+    return () => observer && observer.disconnect();
+  }, [src, loadedSrc]);
+
+  return <img ref={imgRef} src={loadedSrc} alt={alt} loading="lazy" {...rest} />;
+};
+
+export default LazyImage;

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import GlobalAnimations from './HeroAnimations';
 import logoImage from '../../assets/logo_cropped.png';
+import LazyImage from '../Common/LazyImage';
 
 // Animation for floating effect
 const float = keyframes`
@@ -554,7 +555,7 @@ const Hero = () => {
         <HeroImageContainer isRTL={isRTL}>
           <div className="float-element">
             <LogoContainer>
-              <img src={logoImage} alt="S.N.P Logo" loading="lazy" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+              <LazyImage src={logoImage} alt="S.N.P Logo" style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
               
               {/* Floating bubbles */}
               <FloatingBubble style={{ top: '-30px', left: isRTL ? 'auto' : '-30px', right: isRTL ? '-30px' : 'auto', background: 'var(--accent-2)', opacity: 0.25, width: '60px', height: '60px', filter: 'blur(8px)' }} />


### PR DESCRIPTION
## Summary
- create `LazyImage` component using IntersectionObserver
- replace hero section image with `LazyImage` for deferred loading

## Testing
- `npm run lint`
- `npm test` *(fails due to Firebase config)*
- `node src/__tests__/runTests.js`
- `npm run build`
