### PR TITLE
[Dashboard] Implement code splitting

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
@@ -52,15 +52,15 @@ import {
 import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import Navbar from '../Layout/Navbar';
-import Sidebar from './Sidebar';
-import ProjectsPanel from './ProjectsPanel';
-import ProjectNotes from './ProjectNotes';
-import AddProjectModal from './AddProjectModal';
-import TasksPanel from './TasksPanel';
-import FilesPanel from './FilesPanel';
-import FormsPanel from './FormsPanel';
-import TimelinePanel from './TimelinePanel';
-import DesignPanel from './DesignPanel';
+const Sidebar = lazy(() => import('./Sidebar'));
+const ProjectsPanel = lazy(() => import('./ProjectsPanel'));
+const ProjectNotes = lazy(() => import('./ProjectNotes'));
+const AddProjectModal = lazy(() => import('./AddProjectModal'));
+const TasksPanel = lazy(() => import('./TasksPanel'));
+const FilesPanel = lazy(() => import('./FilesPanel'));
+const FormsPanel = lazy(() => import('./FormsPanel'));
+const TimelinePanel = lazy(() => import('./TimelinePanel'));
+const DesignPanel = lazy(() => import('./DesignPanel'));
 
 const Dashboard = () => {
   const { currentUser, logout, loading } = useAuth();
@@ -246,6 +246,14 @@ const Dashboard = () => {
   }
 
   return (
+    <Suspense
+      fallback={(
+        <DashboardLoading>
+          <LoadingSpinner />
+          <p>{t('dashboard.loading', 'Loading Dashboard...')}</p>
+        </DashboardLoading>
+      )}
+    >
     <DashboardPage
       onTouchStart={handlePageTouchStart}
       onTouchMove={handlePageTouchMove}
@@ -484,6 +492,7 @@ const Dashboard = () => {
         </ContentArea>
       </DashboardBody>
     </DashboardPage>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
## Summary
- use `React.lazy` for dashboard subcomponents
- wrap dashboard body in `Suspense` with loading fallback

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'react'))*
- `npm run build`
