### PR TITLE
[AuthModal] Add ARIA labels for accessibility

### DIFF
--- a/src/components/Common/AuthModal.js
+++ b/src/components/Common/AuthModal.js
@@ -270,7 +270,15 @@ const AuthModal = ({ isOpen, onClose }) => {
             <OverlaySpinner />
           </ModalLoadingOverlay>
         )}
-        <CloseText onClick={handleClose}>×</CloseText>
+        <CloseText
+          onClick={handleClose}
+          role="button"
+          tabIndex={0}
+          aria-label={t('auth.close', 'Close')}
+          onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClose()}
+        >
+          ×
+        </CloseText>
         
         <ModalHeader>
           <ModalTitle>
@@ -288,7 +296,11 @@ const AuthModal = ({ isOpen, onClose }) => {
                 // Sign in options
                 <>
                   <AuthOptionsContainer>
-                    <SocialButton onClick={handleGoogleSignIn} disabled={loading}>
+                    <SocialButton
+                      onClick={handleGoogleSignIn}
+                      disabled={loading}
+                      aria-label={t('auth.continueWithGoogle', 'Continue with Google')}
+                    >
                       {loadingMethod === 'google' ? <ButtonSpinner /> : <FaGoogle />}
                       <span>
                         {loadingMethod === 'google'
@@ -297,12 +309,20 @@ const AuthModal = ({ isOpen, onClose }) => {
                       </span>
                     </SocialButton>
                     
-                    <SocialButton onClick={showEmailSignInForm} disabled={loading}>
+                    <SocialButton
+                      onClick={showEmailSignInForm}
+                      disabled={loading}
+                      aria-label={t('auth.continueWithEmail', 'Continue with Email')}
+                    >
                       <FaEnvelope />
                       <span>{t('auth.continueWithEmail', 'Continue with Email')}</span>
                     </SocialButton>
                     
-                    <SocialButton onClick={handlePhoneAuth} disabled={loading || isVerificationSent}>
+                    <SocialButton
+                      onClick={handlePhoneAuth}
+                      disabled={loading || isVerificationSent}
+                      aria-label={t('auth.continueWithPhone', 'Continue with Phone')}
+                    >
                       {loadingMethod === 'phone' ? <ButtonSpinner /> : <FaPhone />}
                       <span>
                         {loadingMethod === 'phone'
@@ -316,11 +336,16 @@ const AuthModal = ({ isOpen, onClose }) => {
                         <Input
                           type="text"
                           placeholder={t('auth.verificationCode', 'Verification Code')}
+                          aria-label={t('auth.verificationCode', 'Verification Code')}
                           value={verificationCode}
                           onChange={(e) => setVerificationCode(e.target.value)}
                           isRTL={isRTL}
                         />
-                        <PhoneButton onClick={handleVerifyCode} disabled={loading}>
+                        <PhoneButton
+                          onClick={handleVerifyCode}
+                          disabled={loading}
+                          aria-label={t('auth.verify', 'Verify')}
+                        >
                           {loadingMethod === 'verify' ? (
                             <>
                               <ButtonSpinner />
@@ -339,7 +364,15 @@ const AuthModal = ({ isOpen, onClose }) => {
               ) : (
                 // Email sign in form
                 <>
-                  <BackButton onClick={backToOptions}>←</BackButton>
+                  <BackButton
+                    onClick={backToOptions}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={t('auth.back', 'Back')}
+                    onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && backToOptions()}
+                  >
+                    ←
+                  </BackButton>
                   
                   <Form onSubmit={handleEmailSignIn}>
                     <FormGroup>
@@ -349,6 +382,7 @@ const AuthModal = ({ isOpen, onClose }) => {
                       <Input
                         type="email"
                         placeholder={t('auth.email', 'Email')}
+                        aria-label={t('auth.email', 'Email')}
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         isRTL={isRTL}
@@ -363,6 +397,7 @@ const AuthModal = ({ isOpen, onClose }) => {
                       <Input
                         type="password"
                         placeholder={t('auth.password', 'Password')}
+                        aria-label={t('auth.password', 'Password')}
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         isRTL={isRTL}
@@ -370,7 +405,11 @@ const AuthModal = ({ isOpen, onClose }) => {
                       />
                     </FormGroup>
                     
-                    <Button type="submit" disabled={loading}>
+                    <Button
+                      type="submit"
+                      disabled={loading}
+                      aria-label={t('auth.signIn', 'Sign In')}
+                    >
                       {loadingMethod === 'emailSignIn' ? (
                         <>
                           <ButtonSpinner />
@@ -386,7 +425,13 @@ const AuthModal = ({ isOpen, onClose }) => {
               
               <SignUpPrompt>
                 {t('auth.noAccount', "Don't have an account?")}{' '}
-                <SignUpLink onClick={toggleSignUpMode}>
+                <SignUpLink
+                  onClick={toggleSignUpMode}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={t('auth.signUp', 'Sign Up')}
+                  onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleSignUpMode()}
+                >
                   {t('auth.signUp', 'Sign Up')}
                 </SignUpLink>
               </SignUpPrompt>
@@ -398,7 +443,11 @@ const AuthModal = ({ isOpen, onClose }) => {
                 // Sign up options
                 <>
                   <AuthOptionsContainer>
-                    <SocialButton onClick={handleGoogleSignIn} disabled={loading}>
+                    <SocialButton
+                      onClick={handleGoogleSignIn}
+                      disabled={loading}
+                      aria-label={t('auth.signUpWithGoogle', 'Sign up with Google')}
+                    >
                       {loadingMethod === 'google' ? <ButtonSpinner /> : <FaGoogle />}
                       <span>
                         {loadingMethod === 'google'
@@ -407,12 +456,20 @@ const AuthModal = ({ isOpen, onClose }) => {
                       </span>
                     </SocialButton>
                     
-                    <SocialButton onClick={showEmailSignInForm} disabled={loading}>
+                    <SocialButton
+                      onClick={showEmailSignInForm}
+                      disabled={loading}
+                      aria-label={t('auth.signUpWithEmail', 'Sign up with Email')}
+                    >
                       <FaEnvelope />
                       <span>{t('auth.signUpWithEmail', 'Sign up with Email')}</span>
                     </SocialButton>
                     
-                    <SocialButton onClick={handlePhoneAuth} disabled={loading || isVerificationSent}>
+                    <SocialButton
+                      onClick={handlePhoneAuth}
+                      disabled={loading || isVerificationSent}
+                      aria-label={t('auth.signUpWithPhone', 'Sign up with Phone')}
+                    >
                       {loadingMethod === 'phone' ? <ButtonSpinner /> : <FaPhone />}
                       <span>
                         {loadingMethod === 'phone'
@@ -426,11 +483,16 @@ const AuthModal = ({ isOpen, onClose }) => {
                         <Input
                           type="text"
                           placeholder={t('auth.verificationCode', 'Verification Code')}
+                          aria-label={t('auth.verificationCode', 'Verification Code')}
                           value={verificationCode}
                           onChange={(e) => setVerificationCode(e.target.value)}
                           isRTL={isRTL}
                         />
-                        <PhoneButton onClick={handleVerifyCode} disabled={loading}>
+                        <PhoneButton
+                          onClick={handleVerifyCode}
+                          disabled={loading}
+                          aria-label={t('auth.verify', 'Verify')}
+                        >
                           {loadingMethod === 'verify' ? (
                             <>
                               <ButtonSpinner />
@@ -449,7 +511,15 @@ const AuthModal = ({ isOpen, onClose }) => {
               ) : (
                 // Email sign up form
                 <>
-                  <BackButton onClick={backToOptions}>←</BackButton>
+                  <BackButton
+                    onClick={backToOptions}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={t('auth.back', 'Back')}
+                    onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && backToOptions()}
+                  >
+                    ←
+                  </BackButton>
                   
                   <Form onSubmit={handleEmailSignUp}>
                     <FormGroup>
@@ -459,6 +529,7 @@ const AuthModal = ({ isOpen, onClose }) => {
                       <Input
                         type="text"
                         placeholder={t('auth.name', 'Full Name')}
+                        aria-label={t('auth.name', 'Full Name')}
                         value={displayName}
                         onChange={(e) => setDisplayName(e.target.value)}
                         isRTL={isRTL}
@@ -473,6 +544,7 @@ const AuthModal = ({ isOpen, onClose }) => {
                       <Input
                         type="email"
                         placeholder={t('auth.email', 'Email')}
+                        aria-label={t('auth.email', 'Email')}
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         isRTL={isRTL}
@@ -487,6 +559,7 @@ const AuthModal = ({ isOpen, onClose }) => {
                       <Input
                         type="password"
                         placeholder={t('auth.password', 'Password')}
+                        aria-label={t('auth.password', 'Password')}
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         isRTL={isRTL}
@@ -494,7 +567,11 @@ const AuthModal = ({ isOpen, onClose }) => {
                       />
                     </FormGroup>
                     
-                    <Button type="submit" disabled={loading}>
+                    <Button
+                      type="submit"
+                      disabled={loading}
+                      aria-label={t('auth.createAccount', 'Create Account')}
+                    >
                       {loadingMethod === 'emailSignUp' ? (
                         <>
                           <ButtonSpinner />
@@ -510,7 +587,13 @@ const AuthModal = ({ isOpen, onClose }) => {
               
               <SignUpPrompt>
                 {t('auth.haveAccount', 'Already have an account?')}{' '}
-                <SignUpLink onClick={toggleSignUpMode}>
+                <SignUpLink
+                  onClick={toggleSignUpMode}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={t('auth.signIn', 'Sign In')}
+                  onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && toggleSignUpMode()}
+                >
                   {t('auth.signIn', 'Sign In')}
                 </SignUpLink>
               </SignUpPrompt>

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -209,7 +209,9 @@
     "errorCodeExpired": "انتهت صلاحية رمز التحقق. يرجى طلب رمز جديد.",
     "errorVerifyFailed": "فشل التحقق. يرجى المحاولة مرة أخرى.",
     "errorInvalidEmail": "يرجى إدخال بريد إلكتروني صالح",
-    "errorWeakPassword": "يجب أن تحتوي كلمة المرور على أحرف وأرقام"
+    "errorWeakPassword": "يجب أن تحتوي كلمة المرور على أحرف وأرقام",
+    "close": "إغلاق",
+    "back": "رجوع"
   },
   
   "dashboard": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -191,7 +191,9 @@
     "errorCodeExpired": "Verification code has expired. Please request a new code.",
     "errorVerifyFailed": "Verification failed. Please try again.",
     "errorInvalidEmail": "Please enter a valid email address",
-    "errorWeakPassword": "Password must contain letters and numbers"
+    "errorWeakPassword": "Password must contain letters and numbers",
+    "close": "Close",
+    "back": "Back"
   },
   
   "dashboard": {


### PR DESCRIPTION
## Summary
- add `close` and `back` translations for auth context
- apply ARIA labels to interactive elements in `AuthModal`

## Testing
- `npm run lint` *(fails: 9 errors in Dashboard.js)*
- `node src/__tests__/runTests.js`
- `npm run build` *(fails: eslint errors in Dashboard.js)*