### PR TITLE
[Navbar] Add keyboard accessible language switcher

### DIFF
--- a/src/__tests__/LanguageSwitcher.test.js
+++ b/src/__tests__/LanguageSwitcher.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, fireEvent } from './testUtils';
+import LanguageSwitcher from '../components/Common/LanguageSwitcher';
+
+const mockChangeLanguage = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { language: 'en', changeLanguage: mockChangeLanguage }
+  })
+}));
+
+describe('LanguageSwitcher Keyboard Accessibility', () => {
+  test('triggers language change on Enter key press', () => {
+    const { getByRole } = render(<LanguageSwitcher />);
+    const button = getByRole('button');
+    fireEvent.keyDown(button, { key: 'Enter', code: 'Enter', charCode: 13 });
+    expect(mockChangeLanguage).toHaveBeenCalledWith('ar');
+  });
+});

--- a/src/components/Common/LanguageSwitcher.js
+++ b/src/components/Common/LanguageSwitcher.js
@@ -12,8 +12,25 @@ const LanguageSwitcher = ({ className }) => {
     setDocumentDirection(newLanguage);
   };
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleLanguageChange();
+    }
+  };
+
   return (
-    <SwitcherIconButton className={className} onClick={handleLanguageChange} title={i18n.language === 'en' ? 'العربية' : 'English'}>
+    <SwitcherIconButton
+      className={className}
+      onClick={handleLanguageChange}
+      onKeyDown={handleKeyDown}
+      aria-label={
+        i18n.language === 'en'
+          ? t('navbar.switchToArabic', 'Switch to Arabic')
+          : t('navbar.switchToEnglish', 'Switch to English')
+      }
+      title={i18n.language === 'en' ? 'العربية' : 'English'}
+    >
       {i18n.language === 'en' ? 'AR' : 'EN'}
     </SwitcherIconButton>
   );
@@ -35,11 +52,16 @@ const SwitcherIconButton = styled.button`
   cursor: pointer;
   transition: background 0.2s, box-shadow 0.2s;
   outline: none;
-  
+
   &:hover {
     background: var(--accent-1);
     color: var(--dark);
     box-shadow: 0 4px 16px rgba(250,170,147,0.15);
+  }
+
+  &:focus-visible {
+    outline: 2px dashed var(--accent-1);
+    outline-offset: 3px;
   }
 `;
 

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -7,7 +7,9 @@
     "contact": "اتصل بنا",
     "login": "تسجيل الدخول",
     "dashboard": "لوحة التحكم",
-    "language": "English"
+    "language": "English",
+    "switchToArabic": "التبديل إلى العربية",
+    "switchToEnglish": "التبديل إلى الإنجليزية"
   },
   "hero": {
     "welcome": "مرحباً بك!",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -7,7 +7,9 @@
     "contact": "Contact",
     "login": "Login",
     "dashboard": "Dashboard",
-    "language": "Arabic"
+    "language": "Arabic",
+    "switchToArabic": "Switch to Arabic",
+    "switchToEnglish": "Switch to English"
   },
   "hero": {
     "welcome": "Hello there!",


### PR DESCRIPTION
## Summary
- update LanguageSwitcher to handle keyboard events
- add focus-visible styling
- provide aria-labels for better screen reader support
- add i18n keys for language switcher labels
- test keyboard accessibility of the language switcher

## Testing
- `npm run lint`
- `npm test` *(fails: Firebase initialization errors)*
- `npm run build` *(fails: ESLint errors during build)*