### PR TITLE
[Dashboard] Improve accessibility of sidebar toggle

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,4 +1,12 @@
-import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  lazy,
+  Suspense,
+  useMemo,
+  useCallback
+} from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
@@ -288,8 +296,16 @@ const Dashboard = () => {
       
       <NavbarArea>
         <NavbarContent>
-          <MenuIconWrapper data-testid="menu-toggle" isRTL={isRTL} onClick={toggleSidebar}>
-            <FaBars />
+          <MenuIconWrapper
+            as="button"
+            type="button"
+            aria-label={t('dashboard.toggleSidebar', 'Toggle sidebar')}
+            aria-expanded={sidebarOpen}
+            data-testid="menu-toggle"
+            isRTL={isRTL}
+            onClick={toggleSidebar}
+          >
+            <FaBars aria-hidden="true" />
           </MenuIconWrapper>
           <Navbar hideMenu={true} />
         </NavbarContent>
@@ -307,7 +323,12 @@ const Dashboard = () => {
         </SidebarArea>
         
         {mobileView && sidebarOpen && (
-          <SidebarBackdrop data-testid="sidebar-backdrop" onClick={toggleSidebar} />
+          <SidebarBackdrop
+            type="button"
+            aria-label={t('dashboard.closeSidebar', 'Close sidebar')}
+            data-testid="sidebar-backdrop"
+            onClick={toggleSidebar}
+          />
         )}
         
         <ContentArea
@@ -571,7 +592,7 @@ const SidebarArea = styled.div`
   }
 `;
 
-const SidebarBackdrop = styled.div`
+const SidebarBackdrop = styled.button`
   position: fixed;
   top: 70px;
   left: 0;
@@ -580,6 +601,10 @@ const SidebarBackdrop = styled.div`
   background: rgba(0, 0, 0, 0.5);
   z-index: 1000;
   cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+
 
   @media (max-width: 768px) {
     top: 60px;
@@ -630,7 +655,9 @@ const MenuIconWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  
+  background: none;
+  border: none;
+
   svg {
     color: #fff;
     font-size: 1.2rem;

--- a/src/components/Dashboard/Sidebar.js
+++ b/src/components/Dashboard/Sidebar.js
@@ -178,6 +178,7 @@ const Sidebar = ({ collapsed = false, onToggleCollapse, onClose }) => {
             <IconWrapper
               isRTL={isRTL}
               isActive={isItemActive(item.path) || item.isHighlighted}
+              aria-hidden="true"
             >
               {item.icon}
             </IconWrapper>


### PR DESCRIPTION
## Summary
- run codex setup
- add missing React hooks imports
- make sidebar toggle focusable button with ARIA labels
- convert sidebar backdrop to a button and add screen reader label
- hide sidebar icons from screen readers

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
- `npm run build`
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'getProvider'))*