### PR TITLE
[Dashboard] Add summary card component

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -10,6 +10,7 @@ import {
   PanelHeader as SharedPanelHeader,
   Card,
   Grid,
+  CardGrid,
   FlexContainer,
   IconButton,
   PrimaryButton,
@@ -54,6 +55,7 @@ import 'react-circular-progressbar/dist/styles.css';
 import Navbar from '../Layout/Navbar';
 import Sidebar from './Sidebar';
 import VirtualizedList from '../Common/VirtualizedList';
+import SummaryCard from './SummaryCard';
 
 
 const ProjectsPanel = lazy(() => import('./ProjectsPanel'));
@@ -355,6 +357,29 @@ const Dashboard = () => {
                     </ProgressInfoContainer>
                   </WelcomeLayout>
                 </WelcomeSection>
+
+                <SummaryGrid>
+                  <SummaryCard
+                    icon={<FaProjectDiagram />}
+                    title={t('dashboard.activeProjects', 'Active Projects')}
+                    value={mockData.activeProjects}
+                  />
+                  <SummaryCard
+                    icon={<FaClipboardList />}
+                    title={t('dashboard.pendingActions', 'Pending Actions')}
+                    value={3}
+                  />
+                  <SummaryCard
+                    icon={<FaFileUpload />}
+                    title={t('dashboard.latestUploads', 'Latest Uploads')}
+                    value={2}
+                  />
+                  <SummaryCard
+                    icon={<FaCalendarAlt />}
+                    title={t('dashboard.projectDeadlines', 'Project Deadlines')}
+                    value={mockData.totalProjects}
+                  />
+                </SummaryGrid>
                 
                 {/* Dashboard Panels */}
                 <DashboardPanels>
@@ -830,6 +855,10 @@ const ProgressInfoContainer = styled.div`
     padding: 1rem;
     gap: 1rem;
   }
+`;
+
+const SummaryGrid = styled(CardGrid)`
+  margin-bottom: 2rem;
 `;
 
 const CompactProgressTitle = styled(ProgressTitle)`

--- a/src/components/Dashboard/SummaryCard.js
+++ b/src/components/Dashboard/SummaryCard.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Card } from '../../styles/GlobalComponents';
+import { useTranslation } from 'react-i18next';
+
+const SummaryCardWrapper = styled(Card)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`;
+
+const IconWrapper = styled.div`
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: ${props => props.color || '#cd3efd'};
+`;
+
+const ValueText = styled.div`
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+`;
+
+const LabelText = styled.div`
+  font-size: 0.9rem;
+  color: #ccc;
+`;
+
+const SummaryCard = ({ icon, title, value, color }) => {
+  const { i18n } = useTranslation();
+  const isRTL = i18n.language === 'ar';
+
+  return (
+    <SummaryCardWrapper dir={isRTL ? 'rtl' : 'ltr'}>
+      {icon && <IconWrapper color={color}>{icon}</IconWrapper>}
+      {value !== undefined && <ValueText>{value}</ValueText>}
+      <LabelText>{title}</LabelText>
+    </SummaryCardWrapper>
+  );
+};
+
+export default SummaryCard;


### PR DESCRIPTION
## Summary
- add `SummaryCard` component for dashboard stats
- show summary cards on the dashboard overview

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
