### PR TITLE
[Dashboard] Add payment history component

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -414,6 +414,14 @@ The Tooltip component provides additional context when hovering over icons or bu
     <IconButton icon={<FaInfo />} />
   </Tooltip>
   ```
+### Payment History Component
+
+A reusable component that lists invoice payments with status badges.
+
+- **Location**: `src/components/Dashboard/Invoicing/PaymentHistory.js`
+- **Reusability**: Can be used in any dashboard section to show transaction records.
+- **Features**: Supports RTL layout, uses shared Panel components, and status badges for payment states.
+
 
 ## Future Enhancements
 

--- a/src/components/Dashboard/Invoicing/PaymentHistory.js
+++ b/src/components/Dashboard/Invoicing/PaymentHistory.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import {
+  PanelContainer,
+  PanelHeader,
+  PanelTitle,
+  EmptyState,
+  StatusBadge
+} from '../../../styles/GlobalComponents';
+import { spacing, colors, typography, borderRadius, shadows } from '../../../styles/GlobalTheme';
+
+/**
+ * PaymentHistory component
+ * Displays a list of payment transactions for a project or client.
+ * Can be reused in other dashboards that require showing transaction history.
+ *
+ * @param {Object[]} transactions - Array of transaction objects
+ */
+const PaymentHistory = ({ transactions = [] }) => {
+  const { t, i18n } = useTranslation();
+  const isRTL = i18n.language === 'ar';
+
+  const formatDate = (date) => {
+    const d = date instanceof Date ? date : new Date(date);
+    return d.toLocaleDateString(i18n.language);
+  };
+
+  return (
+    <PanelContainer dir={isRTL ? 'rtl' : 'ltr'}>
+      <PanelHeader>
+        <PanelTitle>{t('invoices.paymentHistory', 'Payment History')}</PanelTitle>
+      </PanelHeader>
+      {transactions.length ? (
+        <StyledTable>
+          <thead>
+            <tr>
+              <Th>{t('invoices.date', 'Date')}</Th>
+              <Th>{t('invoices.description', 'Description')}</Th>
+              <Th>{t('invoices.amount', 'Amount')}</Th>
+              <Th>{t('invoices.status', 'Status')}</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map(tx => (
+              <tr key={tx.id}>
+                <Td>{formatDate(tx.date)}</Td>
+                <Td>{tx.description}</Td>
+                <Td>{tx.amount}</Td>
+                <Td>
+                  <StatusBadge status={tx.status}>
+                    {t(`invoices.statuses.${tx.status}`, tx.status)}
+                  </StatusBadge>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </StyledTable>
+      ) : (
+        <EmptyState>
+          <p>{t('invoices.noPayments', 'No payment records found')}</p>
+        </EmptyState>
+      )}
+    </PanelContainer>
+  );
+};
+
+const StyledTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: ${spacing.md};
+  text-align: left;
+
+  [dir='rtl'] & {
+    text-align: right;
+  }
+
+  th, td {
+    padding: ${spacing.sm};
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
+  thead {
+    background: ${colors.background.secondary};
+  }
+`;
+
+const Th = styled.th`
+  font-size: ${typography.fontSizes.sm};
+  font-weight: ${typography.fontWeights.semiBold};
+  color: ${colors.text.secondary};
+`;
+
+const Td = styled.td`
+  font-size: ${typography.fontSizes.sm};
+  color: ${colors.text.primary};
+`;
+
+export default PaymentHistory;

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -342,6 +342,19 @@
     "fileViewed": "{{user}} استعرض {{file}}",
     "milestoneReached": "{{milestone}}"
   },
+  "invoices": {
+    "paymentHistory": "سجل الدفعات",
+    "date": "التاريخ",
+    "description": "الوصف",
+    "amount": "المبلغ",
+    "status": "الحالة",
+    "noPayments": "لا توجد سجلات دفع",
+    "statuses": {
+      "paid": "مدفوع",
+      "pending": "قيد المعالجة",
+      "failed": "فشل"
+    }
+  },
   
   "modal": {
     "close": "إغلاق"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -324,6 +324,19 @@
     "fileViewed": "{{user}} viewed {{file}}",
     "milestoneReached": "{{milestone}}"
   },
+  "invoices": {
+    "paymentHistory": "Payment History",
+    "date": "Date",
+    "description": "Description",
+    "amount": "Amount",
+    "status": "Status",
+    "noPayments": "No payment records found",
+    "statuses": {
+      "paid": "Paid",
+      "pending": "Pending",
+      "failed": "Failed"
+    }
+  },
 
   "forms": {
     "title": "Feedback & Forms",


### PR DESCRIPTION
## Summary
- add PaymentHistory component under Dashboard Invoicing
- include translation keys for payment history in English and Arabic locales
- document new component usage in DOCUMENTATION.md

## Testing
- `npm run lint`
- `npm test` *(fails: Firebase initialization errors)*
- `npm run build`
