### PR TITLE
[Dashboard] Add maintenance guide PDF feature

### DIFF
--- a/UI_DESIGN_DOCUMENTATION.md
+++ b/UI_DESIGN_DOCUMENTATION.md
@@ -206,6 +206,7 @@ The dashboard implements a consistent dark theme with the following design chara
 - **QuickActionsContainer**: Grid of action buttons for common tasks with hover effects
 - **TaskItem**: List items with status indicators (done/pending) and appropriate visual styling
 - **ProgressBar/FocusProgressBar**: Visual indicators for completion status with gradient fills
+- **MaintenanceGuide**: Post-launch checklist component with PDF export capability
 
 ### Buttons
 

--- a/src/components/Dashboard/PostLaunch/MaintenanceGuide.js
+++ b/src/components/Dashboard/PostLaunch/MaintenanceGuide.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import Button from '../../Common/Button';
+
+/**
+ * Post-launch maintenance guide component.
+ * Displays key tips and allows generating a printable PDF.
+ * This component can be reused in other areas where a simple
+ * checklist with PDF export is required.
+ */
+const MaintenanceGuide = () => {
+  const { t, i18n } = useTranslation();
+  const isRTL = i18n.language === 'ar';
+
+  const tips = [
+    t('postLaunch.tips.updateDependencies', 'Keep dependencies updated'),
+    t('postLaunch.tips.monitorErrors', 'Monitor and fix errors promptly'),
+    t('postLaunch.tips.backupData', 'Backup your data regularly'),
+    t('postLaunch.tips.securityUpdates', 'Apply security updates'),
+    t('postLaunch.tips.collectFeedback', 'Collect user feedback'),
+  ];
+
+  const generatePDF = () => {
+    const win = window.open('', 'maintenance-guide');
+    if (!win) return;
+    win.document.write(
+      `<html><head><title>${t('postLaunch.maintenanceGuide', "Here's how to maintain your app")}</title></head>` +
+      '<body>' +
+      `<h1>${t('postLaunch.maintenanceGuide', "Here's how to maintain your app")}</h1>` +
+      '<ul>' +
+      tips.map((tip) => `<li>${tip}</li>`).join('') +
+      '</ul>' +
+      '</body></html>'
+    );
+    win.document.close();
+    win.focus();
+    win.print();
+  };
+
+  return (
+    <Container dir={isRTL ? 'rtl' : 'ltr'}>
+      <Title>{t('postLaunch.maintenanceGuide', "Here's how to maintain your app")}</Title>
+      <TipList dir={isRTL ? 'rtl' : 'ltr'}>
+        {tips.map((tip, idx) => (
+          <li key={idx}>{tip}</li>
+        ))}
+      </TipList>
+      <Button variant="primary" onClick={generatePDF}>
+        {t('postLaunch.downloadPDF', 'Download PDF')}
+      </Button>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  background: linear-gradient(145deg, #1c1c24, #1e1e28);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  padding: 1.5rem;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Title = styled.h3`
+  margin: 0;
+  font-size: 1.25rem;
+  background: linear-gradient(90deg, #cd3efd, #7b2cbf);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+`;
+
+const TipList = styled.ul`
+  margin: 0;
+  padding-left: 1.25rem;
+  li {
+    margin-bottom: 0.5rem;
+  }
+
+  &[dir='rtl'] {
+    padding-left: 0;
+    padding-right: 1.25rem;
+  }
+`;
+
+export default MaintenanceGuide;

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -514,6 +514,17 @@
     "subtitle": "ما يقوله عملائي عن عملي",
     "iconAlt": "أيقونة شهادة العميل"
   },
+  "postLaunch": {
+    "maintenanceGuide": "دليل صيانة التطبيق",
+    "downloadPDF": "تحميل PDF",
+    "tips": {
+      "updateDependencies": "حافظ على تحديث الاعتمادات",
+      "monitorErrors": "راقب الأخطاء وقم بإصلاحها بسرعة",
+      "backupData": "انسخ بياناتك احتياطياً بانتظام",
+      "securityUpdates": "قم بتطبيق التحديثات الأمنية",
+      "collectFeedback": "اجمع آراء المستخدمين"
+    }
+  },
   "seo": {
     "alt": {
       "computer": "أيقونة كمبيوتر",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -459,6 +459,17 @@
     "subtitle": "What my clients say about my work",
     "iconAlt": "Client testimonial icon"
   },
+  "postLaunch": {
+    "maintenanceGuide": "Here's how to maintain your app",
+    "downloadPDF": "Download PDF",
+    "tips": {
+      "updateDependencies": "Keep dependencies updated",
+      "monitorErrors": "Monitor and fix errors promptly",
+      "backupData": "Backup your data regularly",
+      "securityUpdates": "Apply security updates",
+      "collectFeedback": "Collect user feedback"
+    }
+  },
   "seo": {
     "alt": {
       "computer": "Computer icon",


### PR DESCRIPTION
## Summary
- add MaintenanceGuide component for Post-Launch dashboard section
- document MaintenanceGuide in UI guidelines
- update English and Arabic translations

## Testing
- `npm run lint`
- `npm test` *(fails: i18n tests and hero test)*
- `npm run build`