### PR TITLE
[Dashboard] Fix button colors in Design tab

### DIFF
--- a/src/components/Dashboard/DesignSection/DesignFeedback.js
+++ b/src/components/Dashboard/DesignSection/DesignFeedback.js
@@ -143,6 +143,7 @@ const CommentActions = styled.div`
 `;
 
 const ActionButton = styled(Button)`
+  color: white;
   svg {
     margin-${({ dir }) => (dir === 'rtl' ? 'left' : 'right')}: 0.25rem;
   }

--- a/src/components/Dashboard/DesignSection/DesignNavigation.js
+++ b/src/components/Dashboard/DesignSection/DesignNavigation.js
@@ -111,7 +111,7 @@ const NavItem = styled.button`
   padding: 0.85rem 1rem;
   width: 140px;
   background: ${props => props.active ? 'rgba(96, 49, 168, 0.6)' : 'transparent'};
-  color: ${props => props.active ? 'white' : 'rgba(255, 255, 255, 0.7)'};
+  color: white;
   border: none;
   border-radius: 10px;
   font-size: 0.9rem;

--- a/src/components/Dashboard/DesignSection/FigmaEmbed.js
+++ b/src/components/Dashboard/DesignSection/FigmaEmbed.js
@@ -119,7 +119,7 @@ const TabButton = styled.button`
   padding: 0.85rem 1rem;
   width: calc(50% - 0.75rem);
   background: ${props => (props.active ? 'rgba(96, 49, 168, 0.6)' : 'rgba(35, 38, 85, 0.4)')};
-  color: ${props => (props.active ? 'white' : 'rgba(255, 255, 255, 0.7)')};
+  color: white;
   border: none;
   border-radius: 10px;
   cursor: pointer;

--- a/src/components/Dashboard/DesignSection/MockupDetail.js
+++ b/src/components/Dashboard/DesignSection/MockupDetail.js
@@ -135,7 +135,7 @@ const Header = styled.div`
 const CloseButton = styled.button`
   background: none;
   border: none;
-  color: #513a52;
+  color: white;
   font-size: 1.5rem;
   cursor: pointer;
   transition: all 0.2s ease;

--- a/src/components/Dashboard/DesignSection/StylePreferenceForm.js
+++ b/src/components/Dashboard/DesignSection/StylePreferenceForm.js
@@ -225,10 +225,10 @@ const CloseButton = styled.button`
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
-  color: #666;
+  color: white;
 
   &:hover {
-    color: #333;
+    color: #ddd;
   }
 `;
 


### PR DESCRIPTION
## Summary
- update tab button text color in Figma embed
- set navigation tab text to white
- use white text on Design Preferences and mockup close buttons
- ensure feedback action buttons have white text

References task **1.2** in `AI_AGENT_TASKS.md`.

## Testing
- `npm run lint`
- `npm test` *(fails: Internationalization Tests & Firebase init issues)*
- `npm run build`
