### PR TITLE
[Design] Fix StyleGuide tab UI

### DIFF
--- a/src/components/Dashboard/DesignSection/StyleGuide.js
+++ b/src/components/Dashboard/DesignSection/StyleGuide.js
@@ -131,48 +131,48 @@ const ContentWrapper = styled.div`
 const StyledTabs = styled(Tabs)`
   .tab-list {
     display: flex;
-    gap: 0.75rem;
-    margin-bottom: 1.5rem;
+    gap: ${spacing.sm};
+    margin-bottom: ${spacing.md};
     flex-wrap: wrap;
   }
-  
+
   .tab-button {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.65rem 1rem;
-    background: rgba(35, 38, 85, 0.6);
-    color: white;
-    border-radius: 6px;
+    gap: ${spacing.xs};
+    padding: ${spacing.sm} ${spacing.md};
+    background: ${colors.gradients.card};
+    color: ${colors.text.primary};
+    border-radius: ${borderRadius.md};
     border: 1px solid rgba(255, 255, 255, 0.1);
-    font-size: 0.9rem;
-    font-weight: 500;
+    font-size: ${typography.fontSizes.sm};
+    font-weight: ${typography.fontWeights.medium};
     cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    
+    transition: ${transitions.medium};
+    box-shadow: ${shadows.sm};
+
     &:hover {
-      background: rgba(96, 49, 168, 0.7);
+      background: ${colors.gradients.hover};
       transform: translateY(-2px);
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+      box-shadow: ${shadows.md};
     }
-    
+
     &[aria-selected="true"] {
-      background: linear-gradient(45deg, #3a1e65 0%, #6031a8 100%);
-      color: white;
-      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+      background: ${colors.gradients.accent};
+      box-shadow: ${shadows.md};
+      color: ${colors.text.primary};
     }
-    
+
     svg {
       font-size: 1rem;
-      color: rgba(255, 255, 255, 0.8);
+      color: inherit;
     }
   }
-  
+
   .tab-content {
-    background: rgba(18, 20, 44, 0.2);
-    padding: 1.25rem;
-    border-radius: 8px;
+    background: ${colors.gradients.card};
+    padding: ${spacing.md};
+    border-radius: ${borderRadius.lg};
     backdrop-filter: blur(5px);
     border: 1px solid rgba(255, 255, 255, 0.05);
   }


### PR DESCRIPTION
## Summary
- update StyleGuide tab styles with accent gradient and icons

References task **1.3** in `AI_AGENT_TASKS.md`.

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
