### PR TITLE
[Dashboard] Add design kit download feature

### DIFF
--- a/src/__tests__/DesignKit.test.js
+++ b/src/__tests__/DesignKit.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from './testUtils';
+import DesignKit from '../components/Dashboard/DesignSection/DesignKit';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}));
+
+describe('DesignKit Component', () => {
+  test('triggers zip download on click', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      blob: () => Promise.resolve(new Blob(['logo']))
+    });
+
+    const createObjectURL = jest.fn(() => 'blob:url');
+    global.URL.createObjectURL = createObjectURL;
+
+    const link = { click: jest.fn() };
+    const originalCreateElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') {
+        return link;
+      }
+      return originalCreateElement(tag);
+    });
+
+    const { getByText } = render(<DesignKit />);
+    fireEvent.click(getByText('design.downloadDesignKit'));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalled());
+    expect(link.click).toHaveBeenCalled();
+  });
+});

--- a/src/components/Dashboard/DesignPanel.js
+++ b/src/components/Dashboard/DesignPanel.js
@@ -2,9 +2,8 @@ import React, { useState, useEffect, lazy, Suspense } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
 import { 
-  FaFigma, 
-  FaDownload, 
-  FaPalette, 
+  FaFigma,
+  FaPalette,
   FaLayerGroup, 
   FaCode, 
   FaHistory,
@@ -28,6 +27,7 @@ import StyleGuide from './DesignSection/StyleGuide';
 import AssetsLibrary from './DesignSection/AssetsLibrary';
 import PhaseTracker from './DesignSection/PhaseTracker';
 import DesignFeedback from './DesignSection/DesignFeedback';
+import DesignKit from './DesignSection/DesignKit';
 
 const DesignPanel = () => {
   const { t, i18n } = useTranslation();
@@ -91,10 +91,6 @@ const DesignPanel = () => {
       .catch(error => console.error('Error fetching design kit info:', error));
   }, []);
   
-  const handleDownloadDesignKit = () => {
-    // In a real implementation, this would trigger a download
-    alert('Downloading Design Kit...');
-  };
   
   const handleTabChange = (tab) => {
     setActiveTab(tab);
@@ -137,10 +133,7 @@ const DesignPanel = () => {
             <FaFigma />
             {t('design.openInFigma', 'Open in Figma')}
           </FigmaLinkButton>
-          <FigmaLinkButton href="#" onClick={handleDownloadDesignKit}>
-            <FaDownload />
-            {t('design.downloadKit', 'Download Design Kit')}
-          </FigmaLinkButton>
+          <DesignKit />
         </ToolbarContainer>
       </Header>
       

--- a/src/components/Dashboard/DesignSection/DesignKit.js
+++ b/src/components/Dashboard/DesignSection/DesignKit.js
@@ -140,7 +140,7 @@ const DesignKit = () => {
   return (
     <Button onClick={handleDownload}>
       <FaDownload />
-      {t('design.downloadKit', 'Download Design Kit')}
+      {t('design.downloadDesignKit', 'Download Design Kit')}
     </Button>
   );
 };

--- a/src/components/Dashboard/Invoicing/InvoiceDisplay.js
+++ b/src/components/Dashboard/Invoicing/InvoiceDisplay.js
@@ -20,6 +20,22 @@ const InvoiceDisplay = ({ invoice }) => {
   const { t, i18n } = useTranslation();
   const isRTL = i18n.language === 'ar';
 
+  const { label, color } = React.useMemo(() => {
+    if (!invoice) {
+      return { label: '', color: 'neutral' };
+    }
+    switch (invoice.status) {
+      case 'paid':
+        return { label: t('invoices.status.paid', 'Paid'), color: 'success' };
+      case 'pending':
+        return { label: t('invoices.status.pending', 'Pending'), color: 'warning' };
+      case 'overdue':
+        return { label: t('invoices.status.overdue', 'Overdue'), color: 'error' };
+      default:
+        return { label: invoice.status, color: 'neutral' };
+    }
+  }, [invoice?.status, t]);
+
   if (!invoice) {
     return (
       <PanelContainer>
@@ -37,19 +53,6 @@ const InvoiceDisplay = ({ invoice }) => {
     const d = date instanceof Date ? date : new Date(date);
     return format(d, 'PPP', { locale: isRTL ? ar : enUS });
   };
-
-  const { label, color } = React.useMemo(() => {
-    switch (invoice.status) {
-      case 'paid':
-        return { label: t('invoices.status.paid', 'Paid'), color: 'success' };
-      case 'pending':
-        return { label: t('invoices.status.pending', 'Pending'), color: 'warning' };
-      case 'overdue':
-        return { label: t('invoices.status.overdue', 'Overdue'), color: 'error' };
-      default:
-        return { label: invoice.status, color: 'neutral' };
-    }
-  }, [invoice.status, t]);
 
   return (
     <PanelContainer>


### PR DESCRIPTION
## Summary
- integrate DesignKit component into DesignPanel toolbar
- fix translation key for design kit download button
- prevent lint error in InvoiceDisplay by moving useMemo
- add unit test for DesignKit download functionality

## Testing
- `npm run lint`
- `node src/__tests__/runTests.js`
- `npm run test:responsive`
- `npm run build`
