### PR TITLE
[PostLaunch] Update HireAgain navigation

### DIFF
--- a/src/__tests__/hireAgain.test.js
+++ b/src/__tests__/hireAgain.test.js
@@ -1,5 +1,15 @@
 import React from 'react';
 import { render, screen } from './testUtils';
+
+// Mock i18n translation hook
+jest.mock('react-i18next', () => {
+  const actual = jest.requireActual('react-i18next');
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key, fallback) => fallback || key, i18n: { language: 'en' } })
+  };
+});
+
 import HireAgain from '../components/Dashboard/PostLaunch/HireAgain';
 
 describe('HireAgain Component', () => {

--- a/src/components/Dashboard/PostLaunch/HireAgain.js
+++ b/src/components/Dashboard/PostLaunch/HireAgain.js
@@ -17,8 +17,11 @@ const HireAgain = () => {
   const navigate = useNavigate();
   const isRTL = i18n.language === 'ar';
 
+  /**
+   * Navigate user to the contact section so they can start a new project.
+   */
   const handleHire = () => {
-    navigate('/#contact');
+    navigate('/contact');
   };
 
   return (


### PR DESCRIPTION
## Summary
- change HireAgain button to navigate to `/contact`
- mock translations in HireAgain test

## Testing
- `npm run lint && npm test`
- `npm run build`