### PR TITLE
[PostLaunch] Add feedback form translations

### DIFF
--- a/src/__tests__/feedbackForm.test.js
+++ b/src/__tests__/feedbackForm.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from './testUtils';
+import FeedbackForm from '../components/Dashboard/PostLaunch/FeedbackForm';
+
+describe('PostLaunch FeedbackForm', () => {
+  test('renders rating and review fields', () => {
+    render(<FeedbackForm />);
+    expect(screen.getByLabelText(/Rating/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Review/i)).toBeInTheDocument();
+  });
+});

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -565,11 +565,18 @@
       "waving": "أيقونة يد تلوح"
     }
   },
-  "postLaunch": {
+"postLaunch": {
     "hireAgain": {
       "title": "توظيفي مرة أخرى",
       "description": "هل لديك مشروع آخر؟ يسعدني العمل معك من جديد.",
       "button": "توظيفي مجدداً"
+    },
+    "feedbackForm": {
+      "rating": "التقييم",
+      "review": "مراجعة",
+      "submit": "إرسال التقييم",
+      "success": "شكراً لملاحظاتك!",
+      "error": "حدث خطأ أثناء إرسال التقييم. حاول مرة أخرى."
     },
     "designPhaseTracker": {
       "title": "مراحل التصميم",
@@ -691,11 +698,18 @@
     "waving": "أيقونة يد تلوح"
   }
 },
-"postLaunch": {
-  "hireAgain": {
-    "title": "توظيفي مرة أخرى",
-    "description": "هل لديك مشروع آخر؟ يسعدني العمل معك من جديد.",
-    "button": "توظيفي مجدداً"
+  "postLaunch": {
+    "hireAgain": {
+      "title": "توظيفي مرة أخرى",
+      "description": "هل لديك مشروع آخر؟ يسعدني العمل معك من جديد.",
+      "button": "توظيفي مجدداً"
+  },
+  "feedbackForm": {
+    "rating": "التقييم",
+    "review": "مراجعة",
+    "submit": "إرسال التقييم",
+    "success": "شكراً لملاحظاتك!",
+    "error": "حدث خطأ أثناء إرسال التقييم. حاول مرة أخرى."
   },
   "designPhaseTracker": {
     "title": "مراحل التصميم",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -516,6 +516,13 @@
       "title": "Hire me again",
       "description": "Have another project? I'd love to work together again!",
       "button": "Hire me again"
+    },
+    "feedbackForm": {
+      "rating": "Rating",
+      "review": "Review",
+      "submit": "Submit Feedback",
+      "success": "Thank you for your feedback!",
+      "error": "Failed to submit feedback. Please try again."
     }
   },
   "designPhaseTracker": {


### PR DESCRIPTION
## Summary
- add translation keys for post-launch feedback form
- add Arabic translations for feedback form
- include simple FeedbackForm test

## Testing
- `npm run lint`
- `CI=true npm test` *(fails: cannot read properties of undefined)*
- `node src/__tests__/runTests.js`
- `npm run build`
